### PR TITLE
feat: Implement getter and setter

### DIFF
--- a/tests/getter-setter.test.ts
+++ b/tests/getter-setter.test.ts
@@ -1,0 +1,33 @@
+describe('getter and setter', () => {
+	class Category {
+		_name?: string;
+
+		get name(): string {
+			if (this._name) {
+				return this._name
+			} else {
+				return 'empty'
+			}
+		}
+
+		set name(name: string | null | undefined) {
+			if (name != undefined || name != null) {
+				this._name = name
+			}
+		}
+	}
+
+	it('learn getter and setter', () => {
+		const category = new Category()
+		expect(category.name).toBe('empty')
+
+		category.name = "person"
+		expect(category.name).toBe('person')
+
+		category.name = null
+		expect(category.name).toBe('person')
+
+		category.name = ''
+		expect(category.name).toBe('empty')
+	})
+})


### PR DESCRIPTION
Adds getter and setter to the Category class.

BREAKING CHANGE: The previous implementation of the Category class did not have getters and setters. This change introduces getters and setters, which may break existing code that relies on direct access to the private _name property.
