### PR TITLE
fix: use super instead of this in overridden method

### DIFF
--- a/tests/class-method-overriding.test.ts
+++ b/tests/class-method-overriding.test.ts
@@ -17,7 +17,7 @@ describe('class method overriding', () => {
 		}
 
 		sayHello(name: string): string {
-			return `Hello ${name}, my name is ${this.name} and i'm is Manager`
+			return `${super.sayHello(name)} and i'm is Manager`
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where the overridden method was not calling the superclass method.

BREAKING CHANGE: The overridden method now calls the superclass method, which may change the behavior of the overridden method.
