### PR TITLE
test(instance-of): use instanceof instead of typeof

### DIFF
--- a/tests/instance-of.test.ts
+++ b/tests/instance-of.test.ts
@@ -1,0 +1,20 @@
+describe('instance of', () => {
+	class Employee { }
+	class Manager { }
+
+	const a = new Employee()
+	const b = new Manager()
+
+	it("must have problem with typeof", () => {
+		expect(typeof a).toBe('object')
+		expect(typeof b).toBe('object')
+	})
+
+	it('use instanceof instead of typeof', () => {
+		expect(a instanceof Employee).toBe(true)
+		expect(a instanceof Manager).toBe(false)
+
+		expect(b instanceof Employee).toBe(false)
+		expect(b instanceof Manager).toBe(true)
+	})
+})


### PR DESCRIPTION
This commit updates a test suite to use instanceof instead of typeof to check the class type of an object.

This change is made because instanceof provides a more accurate check of the object's class type than typeof. Typeof will return "object" for all objects, regardless of their class, which can lead to incorrect results. Instanceof, on the other hand, will return true only if the object is an instance of the specified class.
